### PR TITLE
fixed symbol index in getData(), added symbol to return array

### DIFF
--- a/class.stockMarketAPI.php
+++ b/class.stockMarketAPI.php
@@ -185,8 +185,8 @@ class StockMarketAPI
 			if ($this->stat === 'all') { 
 				foreach ($data as $item) {
 					  
-					//Add to $return[$symbol] array. Indice 23 is the symbol.
-					$return[$item[23]] = array(
+					//Add to $return[$symbol] array. Indice 24 is the symbol.
+					$return[$item[24]] = array(
 						'price'                       =>  strip_tags($item[0]),
 						'change'                      =>  strip_tags($item[1]),
 						'volume'                      =>  strip_tags($item[2]),
@@ -207,7 +207,8 @@ class StockMarketAPI
 						'price_sales_ratio'           =>  strip_tags($item[17]),
 						'price_book_ratio'            =>  strip_tags($item[18]),
 						'short_ratio'                 =>  strip_tags($item[19]),
-						'name'                 		=>  strip_tags($item[20])
+						'name'                 		=>  strip_tags($item[20]),
+						'symbol'			=>  strip_tags($item[24])
 					);
 				}
 			} else {


### PR DESCRIPTION
The index for the stock symbol value was off by one. I also added the symbol to the returned array, its useful to have it in the value array as well as the key.

If you run
```
$StockMarketAPI = new StockMarketAPI;
$StockMarketAPI->symbol = 'AAPL';
print_r($StockMarketAPI->getData());
```

you used to get
```
Array
(
    [-0.22 - -0.23%] => Array
        (
            [price] => 96.04
            [change] => -0.22
             ...
            [short_ratio] => 1.02
            [name] => Apple Inc.
        )

)
```

and now its 

```
Array
(
    [AAPL] => Array
        (
            [price] => 96.04
            [change] => -0.22
             ...
            [short_ratio] => 1.02
            [name] => Apple Inc.
            [symbol] => AAPL
        )
)
```